### PR TITLE
Build static library when running tests under MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,19 @@
 include_directories(.)
 set(LINKER_SCRIPT "${CMAKE_SOURCE_DIR}/link.T")
 
-add_library(vectrexia_libretro SHARED
-        libretro/libretro.cpp
-        vectrexia.cpp
-        cartridge.cpp
-        m6809_disassemble.cpp
-        m6809.cpp
-        )
+set(VECTREXIA_SOURCE
+	libretro/libretro.cpp
+	vectrexia.cpp
+	cartridge.cpp
+	m6809_disassemble.cpp
+	m6809.cpp
+	)
+
+add_library(vectrexia_libretro SHARED ${VECTREXIA_SOURCE})
+
+if(MSVC)
+	add_library(vectrexia_libretro_static STATIC ${VECTREXIA_SOURCE})
+endif()
 
 set_target_properties(vectrexia_libretro PROPERTIES PREFIX "")
 set(CMAKE_EXE_LINKER_FLAGS "-T ${LINKER_SCRIPT}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,13 @@ set(GTEST_SOURCE m6809opcode_test.cpp m6809_test.cpp cartridge_test.cpp)
 
 add_executable(vectrexia_tests test_runner.cpp ${GTEST_SOURCE})
 
-target_link_libraries(vectrexia_tests vectrexia_libretro)
+if (MSVC)
+	set(LIBRETRO_SRC vectrexia_libretro_static)
+else()
+	set(LIBRETRO_SRC vectrexia_libretro)
+endif()
+
+target_link_libraries(vectrexia_tests ${LIBRETRO_SRC})
 target_link_libraries(vectrexia_tests GTest::gtest)
 target_link_libraries(vectrexia_tests GMock::main)
 


### PR DESCRIPTION
Creates an additional target `vectrexia_libretro_static` when `MSVC` is defined, and links against it when running the tests. The `vectrexia_libretro` target is untouched.